### PR TITLE
Fix BadMapError for the :intent option in thumbnail.ex

### DIFF
--- a/lib/image/options/thumbnail.ex
+++ b/lib/image/options/thumbnail.ex
@@ -96,7 +96,7 @@ defmodule Image.Options.Thumbnail do
 
   defp validate_option({:intent, intent}, options) when intent in @intent do
     intent = Map.fetch!(@intent_map, intent)
-    {:cont, Map.put(options, :intent, intent)}
+    {:cont, Keyword.put(options, :intent, intent)}
   end
 
   defp validate_option({:import_icc_profile, profile}, options)


### PR DESCRIPTION
I had a BadMapError when trying to use the :intent option with `Image.thumbnail!/3` because `options` is a Keyword and not a Map.