### PR TITLE
Add :effort option

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -902,16 +902,30 @@ defmodule Image do
     size of the `png` file at the cost of additional time to
     save the image. All metadata will also be removed.
 
+  * `:effort` is an integer to adjust the level of CPU
+    effort to reduce the file size.
+    The value can be between `1` and `10`, the default is at `7`
+
   #### TIFF images
 
   * `:color_depth` which has the same meaning as for
     PNG images.
+
+  #### WEBP images
+
+  * `:effort` is an integer to adjust the level of CPU
+    effort to reduce the file size.
+    The value can be between `0` and `6`, the default is at `4`
 
   #### Heif images
 
   * `:compression` is the compression strategy to
     be applied. The allowable values are `:hevc`,
     `:avc`, `:jpeg` and `:av1`. The default is `:hevc`.
+
+  * `:effort` is an integer to adjust the level of CPU
+    effort to reduce the file size.
+    The value can be between `0` and `9`, the default is at `4`
 
   ### Returns
 

--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -38,6 +38,7 @@ defmodule Image.Options.Write do
           {:strip_metadata, boolean()}
           | {:icc_profile, Path.t()}
           | {:minimize_file_size, boolean()}
+          | {:effort, 1..10}
 
   @typedoc "Options for writing a tiff file with `Image.write/2`."
   @type tiff_write_option ::
@@ -46,11 +47,13 @@ defmodule Image.Options.Write do
   @typedoc "Options for writing a heif file with `Image.write/2`."
   @type heif_write_option ::
           {:compression, heif_compression()}
+          | {:effort, 0..9}
 
   @typedoc "Options for writing a webp file with `Image.write/2`."
   @type webp_write_option ::
           {:icc_profile, Path.t()}
           | {:strip_metadata, boolean()}
+          | {:effort, 0..6}
 
   @typedoc "Allowable compression types for heif images."
   @type heif_compression :: :hevc | :avc | :jpeg | :av1
@@ -60,6 +63,9 @@ defmodule Image.Options.Write do
 
   @doc false
   defguard is_png(image_type) when image_type == ".png"
+
+  @doc false
+  defguard is_tiff(image_type) when image_type == ".tiff"
 
   def validate_options(options, :require_suffix) when is_list(options) do
     case Keyword.fetch(options, :suffix) do
@@ -186,6 +192,11 @@ defmodule Image.Options.Write do
   end
 
   defp validate_option({:background, background}, options, _image_type) when is_color(background) do
+    {:cont, options}
+  end
+
+  defp validate_option({:effort, _effort}, options, image_type)
+    when not is_jpg(image_type) and not is_tiff(image_type) do
     {:cont, options}
   end
 


### PR DESCRIPTION
I would like to add the :effort option which adjusts the cpu effort.
I found it very useful to write `.avif` files, because the default option makes it quite slow.

This option is available for `png`, `heif`, `webp`, `gif` and maybe more formats (but not for `jpg` and `tiff`).