### PR TITLE
Add :minimize_file_size for webp

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -907,6 +907,13 @@ defmodule Image do
   * `:color_depth` which has the same meaning as for
     PNG images.
 
+  #### WEBP images
+
+  * `:minimize_file_size` is a boolean indicating whether
+    to apply a number of techniques to minimise the file
+    size of the `webp` file at the cost of additional time to
+    save the image. All metadata will also be removed.
+
   #### Heif images
 
   * `:compression` is the compression strategy to


### PR DESCRIPTION
I added a `:minimize_file_size` option for the `webp` format.

To be honest, on my test it did not change anything regarding the file size and the strip doesn't seems to strip any metadata unlike for other formats, but this is not related to `Image` because I have the same result using [Vix](https://github.com/akash-akya/vix).

Maybe it works only on some images, or there is an issue with Vix or libvips.
I'll make some more test later and see.