### PR TITLE
fix conform effort to add .avif and .heic support

### DIFF
--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -230,7 +230,7 @@ defmodule Image.Options.Write do
   defp conform_effort(effort, ".png"), do: effort
 
   # Range 0..9
-  defp conform_effort(effort, ".heif"), do: effort - 1
+  defp conform_effort(effort, image_type) when image_type in [".heif", ".heic", ".avif"], do: effort - 1
 
   # Range 0..6
   defp conform_effort(effort, ".webp"), do: round(effort / 10 * 6)


### PR DESCRIPTION
Apparently, the High Efficiency Image File Format actually concern multiple file extensions such as **heif**, **heic** and **avif**.
But for now, I think there is an issue with **Vix** because it's only possible to write **avif** files.

```elixir
# With Image
iex> "image.jpg" |> Image.open!() |> Image.write("image.heif")
{:error, "Failed to write VipsImage to file"}
iex> "image.jpg" |> Image.open!() |> Image.write("image.heic")
{:error, "Failed to write VipsImage to file"}
iex> "image.jpg" |> Image.open!() |> Image.write("image.avif")
{:ok, %Vix.Vips.Image{ref: #Reference<0.1081433751.827981858.88616>}}

# With Vix
iex> {:ok, image} = Vix.Vips.Image.new_from_file("image.jpg")
{:ok, %Vix.Vips.Image{ref: #Reference<0.1081433751.827981858.88598>}}

# Using write_to_file/2
iex> Vix.Vips.Image.write_to_file(image, "image.heif")
{:error, "Failed to write VipsImage to file"}
iex> Vix.Vips.Image.write_to_file(image, "image.heic")
{:error, "Failed to write VipsImage to file"}
iex> Vix.Vips.Image.write_to_file(image, "image.vips")
:ok

# Using heifsave/2
iex> Vix.Vips.Operation.heifsave(image, "image.heif")
{:error, "operation build: heifsave: Unsupported compression"}
iex> Vix.Vips.Operation.heifsave(image, "image.heic")
{:error, "operation build: heifsave: Unsupported compression"}
iex> Vix.Vips.Operation.heifsave(image, "image.avif")
:ok
```

I guess this is a **Vix** error because I don't have this issue using libvips from the **cli**
I've put an `# OK` comment at the end of the lines to show that there was no error and the file was correctly created.
```bash
# Using heifsave
vips heifsave image.jpg image.heif # OK
vips heifsave image.jpg image.heic # OK
vips heifsave image.jpg image.avif # OK

# Using copy
vips copy image.jpg image.heif # OK
vips copy image.jpg image.heic # OK
vips copy image.jpg image.avif # OK
```

I will probably create an issue in the Vix repository if I don't find anything else.