### PR TITLE
Multiple changes for animated images

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -943,7 +943,7 @@ defmodule Image do
 
   * `:effort` is an integer to adjust the level of CPU
     effort to reduce the file size.
-    The value must be in the range `1..10``, the default
+    The value must be in the range `1..10`, the default
     is `7`.
 
   #### GIF options
@@ -957,7 +957,7 @@ defmodule Image do
 
   * `:effort` is an integer to adjust the level of CPU
     effort to reduce the file size.
-    The value must be in the range `1..10``, the default
+    The value must be in the range `1..10`, the default
     is `7`.
 
   #### Heif images

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -627,12 +627,16 @@ defmodule Image do
   * `:scale` will scale the image on load. The value is
     `1..1024` with a default of `1`.
 
-  * `:page` indicates the image page to be loaded. The
+  * `:page` indicates the first page to be loaded. The
     value is in the range `0..100_000` with a default
-    value of `0`.
+    value of `0`. This parameter is useful on animated images.
 
-  * `:pages` indicates how many pages to load. The value is
-    in the range `1..100_000` with a default value of `1`.
+  * `:pages` indicates the number of pages to load.
+    The value must be between `-1` and `100_000`.
+    The default value is `1`.
+    A value of `-1` would load all the available pages
+    which is useful if you want to keep the animation of
+    the input image.
 
   #### TIFF options
 
@@ -641,17 +645,34 @@ defmodule Image do
     data stored in the image metadata. The default is
     `false`.
 
-  * `:page` indicates the image page to be loaded. The
+  * `:page` indicates the first page to be loaded. The
     value is in the range `0..100_000` with a default
-    value of `0`.
+    value of `0`. This parameter is useful on animated images.
 
-  * `:pages` indicates how many pages to load. The value is
-    in the range `1..100_000` with a default value of `1`.
+  * `:pages` indicates the number of pages to load.
+    The value must be between `-1` and `100_000`.
+    The default value is `1`.
+    A value of `-1` would load all the available pages
+    which is useful if you want to keep the animation of
+    the input image.
 
   #### PNG options
 
   * There are no PNG-specific image loading
     options.
+
+  #### GIF options
+
+  * `:page` indicates the first page to be loaded. The
+    value is in the range `0..100_000` with a default
+    value of `0`. This parameter is useful on animated images.
+
+  * `:pages` indicates the number of pages to load.
+    The value must be between `-1` and `100_000`.
+    The default value is `1`.
+    A value of `-1` would load all the available pages
+    which is useful if you want to keep the animation of
+    the input image.
 
   ### Returns
 
@@ -868,7 +889,7 @@ defmodule Image do
   ### Streaming images and :memory images
 
   * `:suffix` must be specified so that the image is written
-    in the correct format. For example: `suffix: ".jpg"`.
+    in the correct format. For example: `suffix: "jpg"`.
 
   #### JPEG images
 
@@ -919,6 +940,20 @@ defmodule Image do
     to save the image. All metadata will also be removed.
     Using this parameter on a non-animated `WebP` file will
     only remove the metadata as `:strip_metadata` would do.
+
+  * `:effort` is an integer to adjust the level of CPU
+    effort to reduce the file size.
+    The value must be in the range `1..10``, the default
+    is `7`.
+
+  #### GIF options
+
+  * `:interframe_maxerror` Maximum inter-frame error for transparency.
+    The value must be in the range `0..32`.
+    The default is `0`.
+    By increasing this value, the encoder will try to take advantage
+    from temporal redundancy between neighboring frames by enabling
+    higher compression rates.
 
   * `:effort` is an integer to adjust the level of CPU
     effort to reduce the file size.
@@ -1121,7 +1156,7 @@ defmodule Image do
       "some/image.jpg"
       |> Image.open!()
       |> Image.resize!(200)
-      |> Image.stream!(suffix: ".jpg", buffer_size: 5_242_880)
+      |> Image.stream!(suffix: "jpg", buffer_size: 5_242_880)
       |> ExAws.S3.upload("images", "some_object_name.jpg")
       |> ExAws.request()
 

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -889,7 +889,7 @@ defmodule Image do
   ### Streaming images and :memory images
 
   * `:suffix` must be specified so that the image is written
-    in the correct format. For example: `suffix: "jpg"`.
+    in the correct format. For example: `suffix: ".jpg"`.
 
   #### JPEG images
 
@@ -1156,7 +1156,7 @@ defmodule Image do
       "some/image.jpg"
       |> Image.open!()
       |> Image.resize!(200)
-      |> Image.stream!(suffix: "jpg", buffer_size: 5_242_880)
+      |> Image.stream!(suffix: ".jpg", buffer_size: 5_242_880)
       |> ExAws.S3.upload("images", "some_object_name.jpg")
       |> ExAws.request()
 

--- a/lib/image/options/open.ex
+++ b/lib/image/options/open.ex
@@ -35,7 +35,7 @@ defmodule Image.Options.Open do
           {:autorotate, boolean()}
           | {:access, file_access()}
           | {:fail_on, fail_on()}
-          | {:pages, pos_integer()}
+          | {:pages, number()}
           | {:page, 1..100_000}
         ]
 
@@ -43,8 +43,8 @@ defmodule Image.Options.Open do
           {:autorotate, boolean()}
           | {:access, file_access()}
           | {:fail_on, fail_on()}
-          | {:pages, pos_integer()}
-          | {:page, 1..100_000}
+          | {:pages, number()}
+          | {:page, 0..100_000}
           | {:scale, 1..1024}
         ]
 
@@ -115,7 +115,7 @@ defmodule Image.Options.Open do
     {:cont, options}
   end
 
-  def validate_option({:pages, n}, options) when is_integer(n) and n in 1..100_000 do
+  def validate_option({:pages, n}, options) when is_number(n) and n >= -1 and n <= 100_000 do
     options =
       options
       |> Keyword.delete(:pages)

--- a/lib/image/options/open.ex
+++ b/lib/image/options/open.ex
@@ -81,6 +81,7 @@ defmodule Image.Options.Open do
 
   @failure_modes Map.keys(@fail_on_open)
   @default_access :random
+  @default_pages -1
 
   @access [:sequential, :random]
 
@@ -90,8 +91,10 @@ defmodule Image.Options.Open do
         {:error, value}
 
       options ->
-        options = Keyword.put_new(options, :access, @default_access)
-        {:ok, options}
+        {:ok,
+         options
+         |> Keyword.put_new(:access, @default_access)
+         |> Keyword.put_new(:n, @default_pages)}
     end
   end
 

--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -65,22 +65,22 @@ defmodule Image.Options.Write do
   @type heif_compression :: :hevc | :avc | :jpeg | :av1
 
   @doc false
-  defguard is_jpg(image_type) when image_type in ["jpg", "jpeg"]
+  defguard is_jpg(image_type) when image_type in [".jpg", ".jpeg"]
 
   @doc false
-  defguard is_png(image_type) when image_type == "png"
+  defguard is_png(image_type) when image_type == ".png"
 
   @doc false
-  defguard is_webp(image_type) when image_type == "webp"
+  defguard is_webp(image_type) when image_type == ".webp"
 
   @doc false
-  defguard is_tiff(image_type) when image_type in ["tiff", "tif"]
+  defguard is_tiff(image_type) when image_type in [".tiff", ".tif"]
 
   @doc false
-  defguard is_heif(image_type) when image_type in ["heif", "heic", "avif"]
+  defguard is_heif(image_type) when image_type in [".heif", ".heic", ".avif"]
 
   @doc false
-  defguard is_gif(image_type) when image_type == "gif"
+  defguard is_gif(image_type) when image_type == ".gif"
 
   def validate_options(options, :require_suffix) when is_list(options) do
     case Keyword.fetch(options, :suffix) do
@@ -93,7 +93,7 @@ defmodule Image.Options.Write do
   end
 
   def validate_options(path, options) when is_binary(path) and is_list(options) do
-    with {:ok, image_type} <- image_type_from(path, options[:suffix]) do
+    with {:ok, image_type} <- path |> Path.extname() |> image_type_from(options[:suffix]) do
       case Enum.reduce_while(options, options, &validate_option(&1, &2, image_type)) do
         {:error, value} ->
           {:error, value}
@@ -256,10 +256,10 @@ defmodule Image.Options.Write do
   end
 
   defp image_type_from("", suffix) do
-    {:ok, String.trim_leading(suffix, ".")}
+    {:ok, suffix}
   end
 
-  defp image_type_from(path, _suffix) do
-    {:ok, path |> String.split(".") |> List.last() |> String.downcase()}
+  defp image_type_from(extname, _suffix) do
+    {:ok, String.downcase(extname)}
   end
 end

--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -49,6 +49,10 @@ defmodule Image.Options.Write do
           {:compression, heif_compression()}
           | {:effort, 1..10}
 
+  @type gif_write_option ::
+          {:interframe_maxerror, 0..32}
+          | {:effort, 1..10}
+
   @typedoc "Options for writing a webp file with `Image.write/2`."
   @type webp_write_option ::
           {:icc_profile, Path.t()}
@@ -60,16 +64,22 @@ defmodule Image.Options.Write do
   @type heif_compression :: :hevc | :avc | :jpeg | :av1
 
   @doc false
-  defguard is_jpg(image_type) when image_type in [".jpg", ".jpeg"]
+  defguard is_jpg(image_type) when image_type in ["jpg", "jpeg"]
 
   @doc false
-  defguard is_png(image_type) when image_type == ".png"
+  defguard is_png(image_type) when image_type == "png"
 
   @doc false
-  defguard is_webp(image_type) when image_type == ".webp"
+  defguard is_webp(image_type) when image_type == "webp"
 
   @doc false
-  defguard is_tiff(image_type) when image_type == ".tiff"
+  defguard is_tiff(image_type) when image_type in ["tiff", "tif"]
+
+  @doc false
+  defguard is_heif(image_type) when image_type in ["heif", "heic", "avif"]
+
+  @doc false
+  defguard is_gif(image_type) when image_type == "gif"
 
   def validate_options(options, :require_suffix) when is_list(options) do
     case Keyword.fetch(options, :suffix) do
@@ -82,7 +92,7 @@ defmodule Image.Options.Write do
   end
 
   def validate_options(path, options) when is_binary(path) and is_list(options) do
-    with {:ok, image_type} <- image_type_from(Path.extname(path), options[:suffix]) do
+    with {:ok, image_type} <- image_type_from(path, options[:suffix]) do
       case Enum.reduce_while(options, options, &validate_option(&1, &2, image_type)) do
         {:error, value} ->
           {:error, value}
@@ -218,6 +228,11 @@ defmodule Image.Options.Write do
     {:cont, options}
   end
 
+  defp validate_option({:interframe_maxerror, int_max_error}, options, image_type)
+  when is_gif(image_type) and  int_max_error in 0..32 do
+    {:cont, options}
+  end
+
   defp validate_option(option, _options, image_type) do
     {:halt, {:error, invalid_option(option, image_type)}}
   end
@@ -230,7 +245,7 @@ defmodule Image.Options.Write do
   defp conform_effort(effort, ".png"), do: effort
 
   # Range 0..9
-  defp conform_effort(effort, image_type) when image_type in [".heif", ".heic", ".avif"], do: effort - 1
+  defp conform_effort(effort, image_type) when is_heif(image_type), do: effort - 1
 
   # Range 0..6
   defp conform_effort(effort, ".webp"), do: round(effort / 10 * 6)
@@ -240,10 +255,10 @@ defmodule Image.Options.Write do
   end
 
   defp image_type_from("", suffix) do
-    {:ok, suffix}
+    {:ok, String.trim_leading(suffix, ".")}
   end
 
-  defp image_type_from(extname, _suffix) do
-    {:ok, extname}
+  defp image_type_from(path, _suffix) do
+    {:ok, path |> String.split(".") |> List.last() |> String.downcase()}
   end
 end

--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -20,6 +20,7 @@ defmodule Image.Options.Write do
           | tiff_write_option()
           | webp_write_option()
           | heif_write_option()
+          | gif_write_option()
         ]
 
   @typedoc "Options for writing an image stream"


### PR DESCRIPTION
- Add a new `interframe_maxerror` parameter for GIFs which allow to increase compression of the frames of the GIF
- Update the `pages` option to allow the use from `-1` which allow to select all the pages of the animated image
- Some minor changes