### PR TITLE
Update webp scale option

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -610,12 +610,12 @@ defmodule Image do
 
   #### JPEG image options
 
-  * `:shrink` is an integer factor in the range `1..16` by
-    which the image is reduced upon loading. This is an
-    optimization that can result in improved performance and
-    reduced memory usage if the image is being loaded
-    with the intent to resize it to smaller dimensions. The
-    default value is `1` meaning no shrink-on-load.
+  * `:shrink` is an integer factor that should be either
+    `1`, `2`, `4`, `8` or `16` by which the image is reduced
+    upon loading. This is an optimization that can result in
+    improved performance and reduced memory usage if the image
+    is being loaded with the intent to resize it to smaller dimensions.
+    The default value is `1` meaning no shrink-on-load.
 
   * `:autorotate` is a boolean value indicating if
     the image should be rotated according to the orientation
@@ -625,7 +625,11 @@ defmodule Image do
   #### Webp options
 
   * `:scale` will scale the image on load. The value is
-    `1..1024` with a default of `1`.
+    `0..1024` with a default of `1` and can either be a
+    `float` or an `integer`.
+    This option allows to shrink-on-load like the `shrink`
+    option for `jpeg` images. For exemple, setting a `scale`
+    of `0.5` will shrink the image by `2`.
 
   * `:page` indicates the first page to be loaded. The
     value is in the range `0..100_000` with a default

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -622,7 +622,7 @@ defmodule Image do
     data stored in the image metadata. The default is
     `false`.
 
-  #### Webp options
+  #### WebP options
 
   * `:scale` will scale the image on load. The value is
     `0..1024` with a default of `1` and can either be a
@@ -936,7 +936,14 @@ defmodule Image do
   * `:color_depth` which has the same meaning as for
     PNG images.
 
-  #### WEBP images
+  #### WebP images
+
+  * `:scale` will scale the image on load. The value is
+    `0..1024` with a default of `1` and can either be a
+    `float` or an `integer`.
+    This option allows to shrink-on-load like the `shrink`
+    option for `jpeg` images. For exemple, setting a `scale`
+    of `0.5` will shrink the image by `2`.
 
   * `:minimize_file_size` is a boolean which is most useful
     on animated `WebP`. It enables mixed encoding and optimise

--- a/lib/image/options/open.ex
+++ b/lib/image/options/open.ex
@@ -45,7 +45,7 @@ defmodule Image.Options.Open do
           | {:fail_on, fail_on()}
           | {:pages, number()}
           | {:page, 0..100_000}
-          | {:scale, 1..1024}
+          | {:scale, number()}
         ]
 
   @type other_open_options :: [
@@ -114,7 +114,7 @@ defmodule Image.Options.Open do
     {:cont, options}
   end
 
-  def validate_option({:scale, scale}, options) when is_integer(scale) and scale in 1..1024 do
+  def validate_option({:scale, scale}, options) when is_number(scale) and scale >= 0 and scale <= 1024 do
     {:cont, options}
   end
 

--- a/lib/image/options/open.ex
+++ b/lib/image/options/open.ex
@@ -20,7 +20,7 @@ defmodule Image.Options.Open do
           | other_open_options()
 
   @type jpeg_open_options :: [
-          {:shrink, 1..16}
+          {:shrink, 1 | 2 | 4 | 8 | 16}
           | {:autorotate, boolean()}
           | {:access, file_access()}
           | {:fail_on, fail_on()}


### PR DESCRIPTION
After creating [this issue on the libvips repo](https://github.com/libvips/libvips/issues/3352), this is what I understand on WebP processing with libvips :

- WebP can use shrink on load as stated [on the libwebp repository](https://github.com/webmproject/libwebp/blob/main/doc/api.md#advanced-decoding-api)
- The shrink parameter is deprecated on WebP as [stated here](https://github.com/libvips/libvips/issues/3352).
So `scale` should be used to shrink on load, that's why I'm making this PR because it was not possible to put a `scale` inferior to 1
- I discovered that the `jpg` shrink parameter was in fact limited to 1, 2, 4, 8 or 16, so I made changes taking this in consideration