### PR TITLE
Update Image.write options documentation to match the code.

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -941,13 +941,6 @@ defmodule Image do
 
   #### PNG images
 
-  * `:color_depth` is an integer describing the number
-     of bits for each color. The value can be `1`, `2`,
-     `4`, `8` or `16`.  The default is to use the current
-     color depth of the image.  For web applications, `8`
-     bits would be reasonable for photographic images with
-     lower bit depths for monochromatic images or diagrams.
-
   * `:progressive` which has the same meaning and values
       as for JPEG images.
 
@@ -959,11 +952,18 @@ defmodule Image do
   * `:effort` is an integer to adjust the level of CPU
     effort to reduce the file size. The value must be in the
     range `1..10`, the default is `7`.
+    
+  * `:icc_profile` ndicates the icc profile to be attached
+    to the input image. The value may be an inbuilt profile 
+    (`:none`, `:srgb`, `:cmyk`, `:p3`), the name of an icc 
+    profile in the systems profile directory or a full path 
+    to an icc profile file. The default is to use the icc 
+    profile of the input image ifthere is one.
 
   #### TIFF images
 
-  * `:color_depth` which has the same meaning as for
-    PNG images.
+  *  `:icc_profile` which has the same meaning and values
+       as for PNG images.
 
   #### WEBP images
 

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -958,7 +958,7 @@ defmodule Image do
     (`:none`, `:srgb`, `:cmyk`, `:p3`), the name of an icc 
     profile in the systems profile directory or a full path 
     to an icc profile file. The default is to use the icc 
-    profile of the input image ifthere is one.
+    profile of the input image if there is one.
 
   #### TIFF images
 

--- a/lib/image.ex
+++ b/lib/image.ex
@@ -953,7 +953,7 @@ defmodule Image do
     effort to reduce the file size. The value must be in the
     range `1..10`, the default is `7`.
     
-  * `:icc_profile` ndicates the icc profile to be attached
+  * `:icc_profile` indicates the icc profile to be attached
     to the input image. The value may be an inbuilt profile 
     (`:none`, `:srgb`, `:cmyk`, `:p3`), the name of an icc 
     profile in the systems profile directory or a full path 


### PR DESCRIPTION
The write options did not mach the the write options in https://github.com/elixir-image/image/blob/main/lib/image/options/write.ex#L38 there are probably more but these are the two I noticed. I'm honestly not certain where color_depth came from but I'm not a VIPS expert.