### PR TITLE
Fix is_webp/1

### DIFF
--- a/lib/image/options/write.ex
+++ b/lib/image/options/write.ex
@@ -72,7 +72,7 @@ defmodule Image.Options.Write do
   defguard is_png(image_type) when image_type in [".png", ".PNG"]
 
   @doc false
-  defguard is_webp(image_type) when image_type == [".webp", ".WEBP"]
+  defguard is_webp(image_type) when image_type in [".webp", ".WEBP"]
 
   @doc false
   defguard is_tiff(image_type) when image_type in [".tiff", ".tif", ".TIF", ".TIFF"]


### PR DESCRIPTION
Hello,

Just a little change, because the `is_webp/1` guard wasn't working anymore.

Also, in a recent PR I added a `String.downcase()` in this function
```Elixir
defp image_type_from(extname, _suffix) do
  {:ok, String.downcase(extname)}
end
```
It downcases the extname before it is compared in the guards, so you could only keep the downcased extensions in the guards if you want to, it would work in any case, even for `.WebP` for exemple.