### PR TITLE
Allow mixing int and atom values in compose's xy_offsets

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -7996,6 +7996,18 @@ defmodule Image do
     {x, y}
   end
 
+  defp xy_offset(%Vimage{} = base_image, %Vimage{} = overlay, x, y)
+      when is_number(x) and is_atom(y) do
+    y = offset_from(y, Image.height(base_image), Image.height(overlay))
+    {x, y}
+  end
+
+  defp xy_offset(%Vimage{} = base_image, %Vimage{} = overlay, x, y)
+      when is_atom(x) and is_number(y) do
+    x = offset_from(x, Image.width(base_image), Image.width(overlay))
+    {x, y}
+  end
+
   defp xy_offset(%Vimage{} = base_image, %Vimage{} = overlay, x, y) do
     x = offset_from(x, Image.width(base_image), Image.width(overlay))
     y = offset_from(y, Image.height(base_image), Image.height(overlay))


### PR DESCRIPTION
Currently passing something like `[x: center, y: 1_000]` throws an error although Vix allows this.  This proposed commit fixes this.

There were no tests around this function so I have not added any.  If you are interested I'd be happy to write some tests around this function in general.