### PR TITLE
Add `:letter_spacing` option to text functions

### DIFF
--- a/lib/image/options/text.ex
+++ b/lib/image/options/text.ex
@@ -20,6 +20,7 @@ defmodule Image.Options.Text do
           | {:background_stroke_opacity, float()}
           | {:background_fill_opacity, float()}
           | {:padding, [non_neg_integer(), ...]}
+          | {:letter_spacing, :normal | integer()}
           | {:x, :center | :left | :right}
           | {:y, :middle | :top | :bottom}
           | {:autofit, boolean()}
@@ -44,6 +45,7 @@ defmodule Image.Options.Text do
       background_stroke_opacity: 0.7,
       background_fill_opacity: 0.7,
       padding: [0, 0],
+      letter_spacing: :normal,
       x: :center,
       y: :middle,
       autofit: false,
@@ -185,6 +187,15 @@ defmodule Image.Options.Text do
     padding_top = div(Image.height(image), 2)
 
     {:cont, Keyword.put(options, option, [padding_left, padding_top])}
+  end
+
+  defp validate_option({:letter_spacing = option, :normal}, options) do
+    {:cont, Keyword.put(options, option, "normal")}
+  end
+
+  defp validate_option({:letter_spacing = option, letter_spacing}, options)
+      when is_integer(letter_spacing) do
+    {:cont, Keyword.put(options, option, letter_spacing)}
   end
 
   defp validate_option({:fontfile, nil}, options) do

--- a/lib/image/text.ex
+++ b/lib/image/text.ex
@@ -87,6 +87,9 @@ defmodule Image.Text do
     from the image dimensions such that the background covers the
     whole of the impage.  THe default is `[0, 0]`.
 
+  * `:letter_spacing` is the amount of space in pixels between each letter.
+    Default is `:normal`.
+
   * `:background_fill_color` is the background fill color behind
     the text. The default is `:none` which indicates no
     background. Note that if
@@ -220,6 +223,9 @@ defmodule Image.Text do
     from the image dimensions such that the background covers the
     whole of the impage.  THe default is `[0, 0]`.
 
+  * `:letter_spacing` is the amount of space in pixels between each letter.
+    Default is `:normal`.
+
   * `:background_fill_color` is the background fill color behind
     the text. The default is `:none` which indicates no
     background. Note that if
@@ -337,6 +343,9 @@ defmodule Image.Text do
   * `:align` indicates how multiple lines of text are aligned.
     The options are `:left`, `:right` and `:center`. The default
     is `:left`.
+
+  * `:letter_spacing` is the amount of space in pixels between each letter.
+    Default is `:normal`.
 
   #### Options applicable in all cases
 
@@ -457,6 +466,9 @@ defmodule Image.Text do
   * `:align` indicates how multiple lines of text are aligned.
     The options are `:left`, `:right` and `:center`. The default
     is `:left`.
+
+  * `:letter_spacing` is the amount of space in pixels between each letter.
+    Default is `:normal`.
 
   #### Options applicable in all cases
 
@@ -865,6 +877,7 @@ defmodule Image.Text do
           fill: #{options.text_fill_color};
           stroke: #{options.text_stroke_color};
           stroke-width: #{options.text_stroke_width};
+          letter-spacing: #{options.letter_spacing}px;
           text-anchor: "left";
         }
       </style>


### PR DESCRIPTION
This commit adds the `:letter_spacing` option to text functions.  I had originally called it `:tracking` as that is the more technical term but decided to go with what CSS does and is the most understandable.  Happy to rename it to whatever you see fit.