### PR TITLE
Check axis names on converting nx tensor to image

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -7373,6 +7373,12 @@ defmodule Image do
       with {:ok, tensor_format} <- Image.BandFormat.image_format_from_nx(tensor) do
         case Nx.shape(tensor) do
           {width, height, bands} when bands in 1..5 ->
+            {width, height} =
+              case Nx.names(tensor) do
+                [:height, _, _] -> {height, width}
+                _other -> {width, height}
+              end
+
             binary = Nx.to_binary(tensor)
             Vix.Vips.Image.new_from_binary(binary, width, height, bands, tensor_format)
 

--- a/test/nx_interop_test.exs
+++ b/test/nx_interop_test.exs
@@ -40,7 +40,13 @@ if Code.ensure_loaded?(Nx) do
       image = image_path("Kamchatka-2019-8754.jpg")
 
       {:ok, image} = Image.open(image, access: :random)
+
       {:ok, tensor} = Image.to_nx(image)
+      {:ok, image2} = Image.from_nx(tensor)
+
+      assert_images_equal image, image2
+
+      {:ok, tensor} = Image.to_nx(image, shape: :hwc)
       {:ok, image2} = Image.from_nx(tensor)
 
       assert_images_equal image, image2


### PR DESCRIPTION
Currently when converting an `nx` tensor to Image we only check for the shape and we assume it's `{width, height, bands}`. So an example like this will fail:
```elixir
image = Image.open!("image.jpeg")
{:ok, tensor} = Image.to_nx(image, shape: :hwc)
{:ok, image2} = Image.from_nx(tensor)
```
In this example `image2` is not the same as `image` and will have its `width` and `height` values swapped.

In this PR, we also check if the name of the first axis of the tensor is `height`, if it's the case, then the `width` and `height` values will be swapped.