### PR TITLE
docs: fixed tiny typo

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -6980,7 +6980,7 @@ defmodule Image do
   end
 
   @doc """
-  Converts an impage to the given colorspace returning
+  Converts an image to the given colorspace returning
   an image or raising an exception.
 
   Available colorspaces are returned from

--- a/lib/image/text.ex
+++ b/lib/image/text.ex
@@ -94,7 +94,7 @@ defmodule Image.Text do
     for the top and bottom of the image.  Another alternative is
     to pass a `t:Vimage.t/0` in which case the padding will be derived
     from the image dimensions such that the background covers the
-    whole of the impage.  THe default is `[0, 0]`.
+    whole of the image.  The default is `[0, 0]`.
 
   * `:align` indicates how multiple lines of text are aligned.
     The options are `:left`, `:right` and `:center`. The default
@@ -248,7 +248,7 @@ defmodule Image.Text do
     for the top and bottom of the image.  Another alternative is
     to pass a `t:Vimage.t/0` in which case the padding will be derived
     from the image dimensions such that the background covers the
-    whole of the impage.  THe default is `[0, 0]`.
+    whole of the image.  The default is `[0, 0]`.
 
   * `:align` indicates how multiple lines of text are aligned.
     The options are `:left`, `:right` and `:center`. The default
@@ -619,7 +619,7 @@ defmodule Image.Text do
     for the top and bottom of the image.  Another alternative is
     to pass a `t:Vimage.t/0` in which case the padding will be derived
     from the image dimensions such that the background covers the
-    whole of the impage.  THe default is `[0, 0]`.
+    whole of the image.  The default is `[0, 0]`.
 
   ### Returns
 
@@ -702,7 +702,7 @@ defmodule Image.Text do
     for the top and bottom of the image.  Another alternative is
     to pass a `t:Vimage.t/0` in which case the padding will be derived
     from the image dimensions such that the background covers the
-    whole of the impage.  THe default is `[0, 0]`.
+    whole of the image.  The default is `[0, 0]`.
 
   ### Returns
 


### PR DESCRIPTION
Hi ! 
This small Pull Request is to fix what I believe was a typo (`impage` instead of `image`).
That's it, Thanks !