### PR TITLE
fix: Fix the bug in the contrast function

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -7825,7 +7825,7 @@ defmodule Image do
 
     without_alpha_band(image, fn image ->
       with_colorspace(image, :scrgb, fn scrgb ->
-        scrgb * contrast - (0.5 * contrast - 0.5)
+        {:ok, scrgb * contrast - (0.5 * contrast - 0.5)}
       end)
     end)
   end


### PR DESCRIPTION
An error occurs when executing the contrast function

<img width="934" alt="error" src="https://github.com/elixir-image/image/assets/14919320/69baf6b0-740f-4d6e-b5a1-ff9927212e03">
