### PR TITLE
Fix add_circles_to_image benchmark

### DIFF
--- a/bench/add_circles_to_image.exs
+++ b/bench/add_circles_to_image.exs
@@ -12,18 +12,22 @@ color = fn -> [Enum.random(1..255), Enum.random(1..255), Enum.random(1..255)] en
 
 {:ok, image} = Image.new(width, height, bands: 3, color: :white)
 
-{time, {:ok, image}} = :timer.tc fn ->
-  Vix.Vips.Image.mutate image, fn mut_img ->
-    Enum.each(1..circles, fn _circle ->
-      :ok = Vix.Vips.MutableImage.draw_circle(mut_img,
-        color.(),
-        cx.(width),
-        cy.(height),
-        radius,
-        fill: true)
+{time, {:ok, image}} =
+  :timer.tc(fn ->
+    Vix.Vips.Image.mutate(image, fn mut_img ->
+      Enum.each(1..circles, fn _circle ->
+        :ok =
+          Vix.Vips.MutableOperation.draw_circle(
+            mut_img,
+            color.(),
+            cx.(width),
+            cy.(height),
+            radius,
+            fill: true
+          )
+      end)
     end)
-  end
-end
+  end)
 
 {:ok, _} = Image.write(image, "test/perf/circles.png")
-IO.puts "#{time / 1_000} milliseconds to generate and add #{circles} random circles to an image"
+IO.puts("#{time / 1_000} milliseconds to generate and add #{circles} random circles to an image")


### PR DESCRIPTION
Wanted to test the `MutableImage` API and found out that the only provided source code is currently broken, this PR fixes this. The other changes are related due to the formatter automatically running, I can remove them from this PR if desired! 😊 