### PR TITLE
Fix bumblebee detection

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -22,7 +22,7 @@ defmodule Image.Application do
   end
 
   # When Bumblebee is available
-  if Code.ensure_loaded?(Bumblebee) do
+  if Image.bumblebee_configured?() do
     @services [
       {{Image.Classification, :classifier, []}, true},
       {{Image.Generation, :generator, []}, false}


### PR DESCRIPTION
Currently, the `Image.Classification` module is loaded when `Bumblebee`, `Nx` and `Exla` are available. However, `Image.Application` calls `Image.Classification` when `Bumblebee` is available. So, if one has `Bumblebee` in deps, but not `Exla`, this error is raised:

```elixir
** (Mix) Could not start application image: exited in: Image.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Image.Classification.classifier/0 is undefined (module Image.Classification is not available)
            Image.Classification.classifier()
            (image 0.54.1) lib/application.ex:34: anonymous fn/2 in Image.Application.children/1
            (elixir 1.17.2) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
            (image 0.54.1) lib/application.ex:18: Image.Application.start/2
            (kernel 10.0) application_master.erl:295: :application_master.start_it_old/4
```

Even though using Bumblebee without Exla may make little sense, this PR aims to fix that by calling `Image.bumblebee_configured?` in both `Application` and `Classification` ;)