### PR TITLE
Bump minimum Elixir version to 1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,13 @@ jobs:
       # Specify the OTP and Elixir versions to use when building
       # and running the workflow steps.
       matrix:
-        otp: ['27.0']       # Define the OTP version [required]
-        elixir: ['1.17.1-otp-27']    # Define the elixir version [required]
+        include:
+          # minimum required versions
+          - otp: "24"
+            elixir: "1.14.0"
+          # latest
+          - otp: "27"
+            elixir: "1.17.2-otp-27"
     steps:
     # Step: Setup Elixir + Erlang image as the base.
     - name: Set up Elixir

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Image.MixProject do
     [
       app: String.to_atom(@app_name),
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.14",
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
       source_url: "https://github.com/kipcole9/image",


### PR DESCRIPTION
I was trying to [update image on a project](https://github.com/BeaconCMS/beacon/actions/runs/10775052364/job/29878588843?pr=586) but it failed with:

```
== Compilation error in file lib/image/exif/decode.ex == Error: ** (CompileError) lib/image/exif/decode.ex:138: size in bitstring expects an integer or a variable as argument, got: :erlang.*(:erlang.byte_size(value), 8)
```

Which was introduce in https://github.com/elixir-image/image/commit/855dfacd5c83761435a3c3d521f9bdff3ead7944, but then working on a fix I realized I was not able to compile it due not meeting Nx requirements:

```
==> nx
warning: the dependency :nx requires Elixir "~> 1.14" but you are running on v1.12.3

Error while loading project :nx
** (Mix) Nx requires Erlang/OTP 24+
```

Since `image` optionally depends on Nx, it seems reasonable to bump the minimum Elixir version to 1.14 and test the minimum required OTP/Elixir on CI, which fixes the initial issue I found too, even though this is a soft breaking change.