### PR TITLE
Make docs for Draw.simple_text less confusing

### DIFF
--- a/lib/image/text.ex
+++ b/lib/image/text.ex
@@ -332,8 +332,7 @@ defmodule Image.Text do
   * `:text_fill_color` is the fill color of the text.
     The default is "white". If set to `:transparent` then
     the text will be rendered transparently against
-    a background. A black background will be forced if a
-    `:background_fill_color` is not provided
+    a background.
 
   * `:dpi` sets the resolution of the text generation. The
     default `72` which is suitable for screen output. `300`
@@ -420,8 +419,7 @@ defmodule Image.Text do
   * `:text_fill_color` is the fill color of the text.
     The default is "white". If set to `:transparent` then
     the text will be rendered transparently against
-    a background. A black background will be forced if a
-    `:background_fill_color` is not provided
+    a background.
 
   * `:font_size` is an integer font size in pixels. The
     default is `50`.


### PR DESCRIPTION
Drop mention of background_fill_color, as it is not evaluated.

Closes #167.