### PR TITLE
Fix typo in doc string

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -4092,9 +4092,9 @@ defmodule Image do
 
   ### Returns
 
-  * `{:ok, pixelated_image}` or
+  * `pixelated_image` or
 
-  * `{:error, reason}`
+  * raises an exception
 
   """
   @doc subject: "Operation", since: "0.14.0"


### PR DESCRIPTION
`pixelate!/1` had a partly copy-pasted doc string from `pixelate/1`