### PR TITLE
open/2: accept generic Enumerables

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -50,7 +50,7 @@ defmodule Image do
   The valid sources of image data when opening an
   image.
   """
-  @type image_data :: Path.t() | File.Stream.t() | binary()
+  @type image_data :: Path.t() | File.Stream.t() | binary() | Enumerable.t()
 
   @typedoc """
   Represents either in image, or a color
@@ -809,19 +809,19 @@ defmodule Image do
     end
   end
 
-  # Any other stream
-  def open(%Stream{} = image_stream, options) do
-    with {:ok, options} <- Options.Open.validate_options(options) do
-      options = loader_options(options)
-      Vix.Vips.Image.new_from_enum(image_stream, options)
-    end
-  end
-
   def open(%File.Stream{}, _options) do
     {:error,
      "File stream must be specify the number of bytes to read. " <>
        "It should be opened as File.stream!(path, options, bytes) where bytes " <>
        "is the number of bytes to read on each iteration."}
+  end
+
+  # Any other stream
+  def open(image_stream, options) do
+    with {:ok, options} <- Options.Open.validate_options(options) do
+      options = loader_options(options)
+      Vix.Vips.Image.new_from_enum(image_stream, options)
+    end
   end
 
   defp do_open([path], options) do


### PR DESCRIPTION
From [the Stream documentation][1]:

> #### Do not check for `Stream` structs
>
> While some functions in this module may return the `Stream` struct,
> you must never explicitly check for the `Stream` struct, as streams
> may come in several shapes, such as `IO.Stream`, `File.Stream`, or
> even `Range`s.
>
> The functions in this module only guarantee to return enumerables
> and their implementation (structs, anonymous functions, etc) may
> change at any time. For example, a function that returns an anonymous
> function today may return a struct in future releases.
>
> Instead of checking for a particular type, you must instead write
> assertive code that assumes you have an enumerable, using the functions
> in the `Enum` or `Stream` module accordingly.

`open/2` currently pattern matches against `%Stream{}` to determine if an image is a Stream. This prevents the use of `Stream.resource/3` and other Stream functions returning otherwise valid anonymous functions. Following the advice of the documentation, this commit removes the struct check and colocates the `File.Stream{}` `open/2` clauses.

Let me know if this is okay, or you want to do something different to handle this :slightly_smiling_face:.

[1]: https://hexdocs.pm/elixir/Stream.html#module-creating-streams