### PR TITLE
`remove_metadata/2` `:xmp` selector is a silent no-op, maps to wrong header name

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -6668,7 +6668,7 @@ defmodule Image do
 
   @metadata_fields %{
     exif: "exif-data",
-    xmp: "xmp-dataa",
+    xmp: "xmp-data",
     iptc: "iptc-data"
   }
 

--- a/test/image_test.exs
+++ b/test/image_test.exs
@@ -35,6 +35,23 @@ defmodule Image.Test do
     assert input_info.size > output_info.size * 2
   end
 
+  test "Remove metadata", %{dir: _dir} do
+    image = image_path("Kip_small.jpg")
+    {:ok, kip} = Vimage.new_from_file(image)
+
+    for {atom_key, raw_header_key} <- [
+          {:exif, "exif-data"},
+          {:xmp, "xmp-data"},
+          {:iptc, "iptc-data"}
+        ] do
+      {:ok, header_fields} = Vix.Vips.Image.header_field_names(kip)
+      assert Enum.member?(header_fields, raw_header_key)
+      {:ok, kip} = Image.remove_metadata(kip, [atom_key])
+      {:ok, header_fields} = Vix.Vips.Image.header_field_names(kip)
+      refute Enum.member?(header_fields, raw_header_key)
+    end
+  end
+
   test "Circular Image", %{dir: dir} do
     image = image_path("Kip_small.jpg")
     {:ok, kip} = Vimage.new_from_file(image)


### PR DESCRIPTION
Removing XMP via the `:xmp` field selector does nothing because the `@metadata_fields` map has a typo (`xmp-dataa`).

**Reproduction**
```elixir
{:ok, base} = Vix.Vips.Operation.black(8, 8, bands: 3)
{:ok, img} =
  Vix.Vips.Image.mutate(base, fn m ->
    Vix.Vips.MutableImage.set(m, "xmp-data", :VipsBlob, "FAKE-XMP")
  end)
# attempt to remove XMP data by atom key
{:ok, a} = Image.remove_metadata(img, :xmp)
Vix.Vips.Image.header_field_names(a)
#=> {:ok,
 ["xmp-data", "filename", "yres", "xres", "yoffset", "xoffset",
  "interpretation", "coding", "format", "bands", "height", "width"]}   # XMP still present
```

**Root cause**
```elixir
@metadata_fields %{
  exif: "exif-data",
  xmp: "xmp-dataa",   # <- should be "xmp-data"
  iptc: "iptc-data"
}
```

I added a test that asserts `:exif`/`:xmp`/`:iptc` removes their respective header, and fixed the typo in the `@metadata_fields` map.