### PR TITLE
Fix: use 0..255 alpha scale for Lab/LCH/LABS

### DIFF
--- a/lib/image/pixel.ex
+++ b/lib/image/pixel.ex
@@ -525,26 +525,20 @@ defmodule Image.Pixel do
     end
   end
 
+  # Encoders grouped by their alpha band's max value
+  @alpha_max_255 [:uchar_rgb, :uchar_cmyk, :uchar_hsv, :uchar_grey, :float_lab, :float_lch, :short_lab]
+  @alpha_max_65535 [:ushort_rgb, :ushort_grey]
+
   # The alpha band uses the same numeric type as the rest of the
   # interpretation: 0..255 for uchar, 0..65535 for ushort, 0.0..1.0
-  # for float-typed bands. LABS / Lab / LCH happen to be float-typed
-  # interpretations whose alpha band is also a float in [0, 1].
+  # for float-typed bands. scRGB is the only float interpretation whose
+  # alpha is in [0, 1]. LABS / Lab / LCH carry a 0..255 alpha band
+  # despite their float/short color bands.
   defp scale_alpha_to_encoder(alpha, encoder) do
     case encoder do
-      e when e in [:uchar_rgb, :uchar_cmyk, :uchar_hsv, :uchar_grey] ->
-        scale(alpha, 255)
-
-      e when e in [:ushort_rgb, :ushort_grey] ->
-        scale(alpha, 65_535)
-
-      :float_rgb ->
-        alpha * 1.0
-
-      e when e in [:float_lab, :float_lch] ->
-        alpha * 1.0
-
-      :short_lab ->
-        round(alpha * 65_535)
+      e when e in @alpha_max_255 -> scale(alpha, 255)
+      e when e in @alpha_max_65535 -> scale(alpha, 65_535)
+      :float_rgb -> alpha * 1.0
     end
   end
 

--- a/test/pixel_test.exs
+++ b/test/pixel_test.exs
@@ -120,6 +120,39 @@ defmodule Image.PixelTest do
     end
   end
 
+  describe "to_pixel/3 alpha scale matches the interpretation's max alpha" do
+    defp with_alpha(colorspace) do
+      {:ok, srgba} = Image.new(2, 2, color: [10, 20, 30, 255])
+      {:ok, image} = Image.to_colorspace(srgba, colorspace)
+      image
+    end
+
+    test "opaque alpha resolves to 255 for every 0..255-scale interpretation" do
+      for colorspace <- [:srgb, :cmyk, :hsv, :bw, :lab, :lch, :labs] do
+        image = with_alpha(colorspace)
+        {:ok, pixel} = Pixel.to_pixel(image, :red, alpha: :opaque)
+        assert List.last(pixel) == 255, "#{colorspace} opaque alpha was #{List.last(pixel)}"
+      end
+    end
+
+    test "scRGB opaque alpha stays 1.0" do
+      image = with_alpha(:scrgb)
+      assert {:ok, [_r, _g, _b, alpha]} = Pixel.to_pixel(image, :red, alpha: :opaque)
+      assert alpha == 1.0
+    end
+
+    test "a plain color (no explicit :alpha) also synthesizes opaque 255 on Lab" do
+      image = with_alpha(:lab)
+      assert {:ok, [_l, _a, _b, 255]} = Pixel.to_pixel(image, :red)
+    end
+
+    test "alpha 0.5 resolves to 128 on Lab" do
+      image = with_alpha(:lab)
+      assert {:ok, [_l, _a, _b, alpha]} = Pixel.to_pixel(image, :red, alpha: 0.5)
+      assert alpha == 128
+    end
+  end
+
   describe "to_pixel/3 against a CMYK image" do
     setup do
       {:ok, image} = Image.new(2, 2, color: :black)


### PR DESCRIPTION
Some of the alpha scales were off in `Image.Pixel`. It looks like scRGB is the only 0..1 alpha band interpretation:

```console
# preamble: add an alpha band to jose.png
$ vips addalpha test/support/images/jose.png /tmp/jose-alpha.png

# lab is 0..255
$ vips colourspace /tmp/jose-alpha.png /tmp/jose.lab.v lab && vips getpoint /tmp/jose.lab.v 0 0
70.435928344726562 -1.6400516033172607 2.3084163665771484 255

# lch is 0..255
$ vips colourspace /tmp/jose-alpha.png /tmp/jose.lch.v lch && vips getpoint /tmp/jose.lch.v 0 0
70.435928344726562 2.8317053318023682 125.39250183105469 255

# labs is 0..255
$ vips colourspace /tmp/jose-alpha.png /tmp/jose.labs.v labs && vips getpoint /tmp/jose.labs.v 0 0
23079 -419 590 255

# scRGB is 0..1
$ vips colourspace /tmp/jose-alpha.png /tmp/jose.scrgb.v scrgb && vips getpoint /tmp/jose.scrgb.v 0 0
0.40724030137062073 0.41788515448570251 0.39157256484031677 1
```

Changes
* `:lab`/`:lch` alpha's scale was 0.0..1.0, now scales to 255
* `:labs` alpha was scaled to 65 535, now scales to 255