### PR TITLE
Hide ForDialyzer module in hexdocs

### DIFF
--- a/mix/for_dialyzer.ex
+++ b/mix/for_dialyzer.ex
@@ -1,4 +1,6 @@
 defmodule ForDialyzer do
+  @moduledoc false
+
   # Juse to exorcise dialyzer errors. This module is not included
   # in the library published to hex.pm.
 


### PR DESCRIPTION
add `@moduledoc false` so it skips generating docs for `ForDialyzer`