### PR TITLE
Add default options to `Draw.point!/4`

### DIFF
--- a/lib/image/draw.ex
+++ b/lib/image/draw.ex
@@ -170,7 +170,7 @@ defmodule Image.Draw do
         ) ::
           Vimage.t() | MutableImage.t() | no_return()
 
-  def point!(image, left, top, options) do
+  def point!(image, left, top, options \\ []) do
     case point(image, left, top, options) do
       {:ok, image} -> image
       {:error, reason} -> raise Image.Error, reason


### PR DESCRIPTION
`Image.Draw.point/4` has an `options \\ []` default but `point!/4` didn't, so `Image.Draw.point!(img, 5, 5)` raised `UndefinedFunctionError`.