### PR TITLE
Correct the `Image.compare/3` option type and use it in the spec

### DIFF
--- a/lib/image.ex
+++ b/lib/image.ex
@@ -13551,7 +13551,7 @@ defmodule Image do
       completely different),
 
     * [:mse](https://en.wikipedia.org/wiki/Mean_squared_error) which
-      is the mean squared error (default). The returned value is a float
+      is the mean squared error. The returned value is a float
       indicating how similar the images are. A value of
       `0.0` means the images are the same. The number itself it simply a
       measure of the error difference between images. A larger number means
@@ -13614,7 +13614,11 @@ defmodule Image do
   @doc since: "0.34.0"
   @doc subject: "Operation"
 
-  @spec compare(Vimage.t(), Vimage.t(), Keyword.t()) ::
+  @spec compare(
+          image_1 :: Vimage.t(),
+          image_2 :: Vimage.t(),
+          options :: Options.Compare.compare_options()
+        ) ::
           {:ok, number, Vimage.t()} | {:error, error()}
   def compare(%Vimage{} = image_1, %Vimage{} = image_2, options \\ []) when is_list(options) do
     with {:ok, options} <- Options.Compare.validate_options(image_1, options),

--- a/lib/image/options/compare.ex
+++ b/lib/image/options/compare.ex
@@ -11,12 +11,17 @@ defmodule Image.Options.Compare do
 
   """
   @type compare_option ::
-          {:color, Pixel.t() | :auto}
-          | {:threshold, non_neg_integer()}
-          | {:greater_than, Pixel.t()}
-          | {:less_than, Pixel.t()}
-          | {:sigma, float()}
-          | {:min_amplitude, float()}
+          {:metric, metric()}
+          | {:saturation, number()}
+          | {:brightness, number()}
+          | {:difference_boost, number()}
+          | {:difference_color, Pixel.t()}
+
+  @typedoc """
+  The comparison metric used by `Image.compare/3`.
+
+  """
+  @type metric :: :ae | :mse | :rmse
 
   @type compare_options :: [compare_option()]
 


### PR DESCRIPTION
Fixed `compare_option/0` to match the options the validator actually accepts. Updated the `compare/3` spec from `Keyword.t()` to `Options.Compare.compare_options()`. Removed an outdated `(default)` marker from the `:mse` doc bullet.